### PR TITLE
fix time of previous messages

### DIFF
--- a/src/components/ui/chat/message/SentMessage.js
+++ b/src/components/ui/chat/message/SentMessage.js
@@ -1,12 +1,12 @@
 import { formatTimestamp } from '../../../../utils/helpers';
 import { SentMessageContainer, SentMessageHeader, SentMessageTimestamp, SentMessageLabel } from '../../common';
 
-const SentMessage = ({ children, created_at }) => {
+const SentMessage = ({ children, timestamp }) => {
   return (
     <SentMessageContainer>
       <SentMessageHeader>
         <SentMessageTimestamp>
-          {formatTimestamp(created_at)}
+          {formatTimestamp(timestamp)}
         </SentMessageTimestamp>
         <SentMessageLabel>
           شما


### PR DESCRIPTION
The time of all previous messages was same as current system time.
<img width="1920" height="1080" alt="Screen Shot 2025-10-05 at 12 38 43 PM" src="https://github.com/user-attachments/assets/0e30bee6-beee-40de-b6de-342a7cbf0c67" />
