### PR TITLE
Apply background wizard style

### DIFF
--- a/src/components/ui/common.js
+++ b/src/components/ui/common.js
@@ -676,10 +676,11 @@ export const WizardButtonStyled = styled.button`
   border-radius: 0.5rem; /* rounded-lg */
   transition: background-color 0.2s ease-in-out;
   box-sizing: border-box;
+  margin-right: 0.125rem;
 
-  // &:hover {
-  //   background-color: #bfdbfe; /* hover:bg-blue-200 */
-  // }
+  &:hover {
+    background-color: #bfdbfe; /* hover:bg-blue-200 */
+  }
 
   /* Dark mode styles (triggered by .dark parent) */
   .dark & {

--- a/src/widget/chatbox/chatbox.css
+++ b/src/widget/chatbox/chatbox.css
@@ -130,8 +130,7 @@
 #khan-chatbox input[type='reset'],
 #khan-chatbox input[type='submit'] {
   -webkit-appearance: button;
-  background-color: inherit;
-}
+} 
 
 #khan-chatbox :-moz-focusring {
   outline: auto;


### PR DESCRIPTION
Removed background-color: inherit; to ensure custom styles apply (WizardButtonStyled).
Added margin-right for spacing between wizard buttons.
<img width="525" height="904" alt="Screen Shot 2025-10-06 at 12 21 47 PM" src="https://github.com/user-attachments/assets/a2de33c0-0822-4222-b646-bb236867145b" />
closes #183