### PR TITLE
fix: unify auth token key to `khan-access-token` and eliminate stale headers #251

### DIFF
--- a/src/contexts/axios.js
+++ b/src/contexts/axios.js
@@ -6,7 +6,7 @@ axios.defaults.baseURL = process.env.REACT_APP_API_URL;
 // Add a request interceptor to include the auth token
 axios.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('khan-access-token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -28,7 +28,7 @@ axios.interceptors.response.use(
       switch (error.response.status) {
         case 401:
           // Unauthorized - clear auth data and redirect to login
-          localStorage.removeItem('token');
+          localStorage.removeItem('khan-access-token');
           localStorage.removeItem('user');
           window.location.href = '/login';
           break;

--- a/src/utils/apis.js
+++ b/src/utils/apis.js
@@ -161,7 +161,7 @@ export const workflowEndpoints = {
         {
           headers: {
             'Content-Type': 'multipart/form-data',
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${localStorage.getItem('khan-access-token')}`,
           },
         }
       );

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -7,7 +7,7 @@ axios.defaults.baseURL =
 // Add a request interceptor to include the auth token
 axios.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('khan-access-token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Problem Solved  
**#251** – After login, Axios kept sending the **old** (or missing) token because the app mixed two keys: `token` **and** `khan-access-token`.  
Result: every request after login → **401 → auto-logout**.

## Solution  
**One key to rule them all**: `khan-access-token`

### Fixed Files
- `src/contexts/axios.js`  
- `src/utils/axios.js`  
- `src/utils/apis.js` (workflow upload)

### What Changed
```diff
- localStorage.getItem('token')
+ localStorage.getItem('khan-access-token')
```

- 
- Interceptors now read the correct key
- 401 handler now clears the correct key
- Manual header in file uploads now matches