### PR TITLE
fix(ui): make dropdown items visible in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -76,8 +76,18 @@ body {
 }
 
 .dark .ck.ck-dropdown__panel .ck.ck-button,
-.dark .ck.ck-dropdown__panel .ck.ck-button__label {
-  color: white !important;
+.dark .ck.ck-dropdown__panel .ck.ck-button__label,
+.dark .ck.ck-dropdown__panel .ck-list__item > .ck-button {
+  background: #374151 !important;
+}
+
+.dark .ck.ck-dropdown__panel .ck-list__item:hover > .ck-button,
+.dark .ck.ck-dropdown__panel .ck.ck-button:hover {
+  background: #1f2937 !important;
+}
+
+.dark .ck.ck-dropdown__panel .ck-list__item:hover .ck-button__label {
+  background: transparent !important;
 }
 
 .dark .ck.ck-input-text {


### PR DESCRIPTION
They are now visible in dark mode and also their background color changes on hover.

<img width="371" height="827" alt="Screen Shot 2025-11-30 at 3 15 23 PM" src="https://github.com/user-attachments/assets/d7fe9a47-7610-40ff-8333-7c90f76113b0" />

closes #316 