### PR TITLE
fix: follow browser history by clicking back button in edit wizard

### DIFF
--- a/src/pages/wizard/UpdateWizard/EditWizardPage.jsx
+++ b/src/pages/wizard/UpdateWizard/EditWizardPage.jsx
@@ -71,10 +71,10 @@ const EditWizardPage = () => {
    * Handle go to previous route
    */
   const handleBack = () => {
-    if (window.history.state && window.history.state.idx > 0) {
+    if (window.history.length > 1) {
       navigate(-1);
     } else {
-      navigate('/wizard');
+      navigate('/wizard', { replace: true });
     }
   };
   


### PR DESCRIPTION
Fixed the Edit Wizard Back button to follow browser history, preserving user navigation context and falling back to `/wizard` only when no previous route exists.

Uploading Screen Recording 2025-12-01 at 4.07.56 PM.mov…

closes #325 