### PR TITLE
fix(ui): use Tangent icon on Document Index

### DIFF
--- a/src/pages/document/DocumentIndex/DocumentIndexPage.jsx
+++ b/src/pages/document/DocumentIndex/DocumentIndexPage.jsx
@@ -132,8 +132,8 @@ const DocumentIndexPage = () => {
             to={'/document/vector-search'}
             className="pr-4 pl-3 py-3 flex items-center justify-center rounded-lg font-medium transition-all bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
           >
-            <span>جستجوری برداری</span>
-            <Icon name="BezierCurve" className="w-[22px] h-[22px] pr-2 box-content" />
+            <span>جستجوی برداری</span>
+            <Icon name="Tangent" size={22} className="pr-2 box-content" />
           </Link>
           <Link
             to={'/document/create'}


### PR DESCRIPTION
Replace missing BezierCurve icon with Tangent (available in current lucide version) to remove warning on /document.
